### PR TITLE
Fix Render deployment path

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ io.on('connection', (socket) => {
   });
 });
 
-const PORT = 4000;
+const PORT = process.env.PORT || 4000;
 server.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);
 });

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "socket-server",
+  "name": "fetregapi",
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
@@ -8,5 +8,10 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "socket.io": "^4.7.5"
+  }
 }


### PR DESCRIPTION
## Summary
- move socket server files to repo root so package.json is discovered
- add required dependencies
- allow port configuration via `process.env.PORT`

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688a50315b68832096a2b0d12b75bb5f